### PR TITLE
Ensure streamable HTTP sessions apply preprompt instructions

### DIFF
--- a/app/instructions.py
+++ b/app/instructions.py
@@ -4,12 +4,42 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from functools import lru_cache
 from pathlib import Path
+from typing import Callable, Mapping
 
 LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_TEXT = """This server provides access to your Grafana instance and the surrounding ecosystem.\n\nAvailable Capabilities:\n- Dashboards: Search, retrieve, update, and create dashboards. Extract panel queries and datasource information.\n- Datasources: List and fetch details for datasources.\n- Prometheus & Loki: Run PromQL and LogQL queries, retrieve metric/log metadata, and explore label names/values.\n- Incidents: Search, create, update, and resolve incidents in Grafana Incident.\n- Sift Investigations: Start and manage Sift investigations, analyze logs/traces, find error patterns, and detect slow requests.\n- Alerting: List and fetch alert rules and notification contact points.\n- OnCall: View and manage on-call schedules, shifts, teams, and users.\n- Admin: List teams and perform administrative tasks.\n- Pyroscope: Profile applications and fetch profiling data.\n- Navigation: Generate deeplink URLs for Grafana resources like dashboards, panels, and Explore queries.\n\nWhen responding, favor concise summaries and include relevant identifiers (dashboard UID, datasource UID, incident ID) so the client can follow up with fetch operations. Avoid expanding raw JSON unless explicitly requested; present key fields and next-step suggestions instead."""
+
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*([A-Z][A-Z0-9_]+)\s*\}\}")
+
+
+def _placeholder_resolver() -> Mapping[str, str]:
+    """Return a mapping of placeholder names to replacement values."""
+
+    # Environment variables take precedence and can be extended without code changes.
+    return {key: value for key, value in os.environ.items() if key}
+
+
+def _replace_placeholders(text: str, value_lookup: Callable[[str], str | None]) -> str:
+    """Replace ``{{PLACEHOLDER}}`` tokens using ``value_lookup`` to resolve values."""
+
+    def _replacement(match: re.Match[str]) -> str:
+        key = match.group(1)
+        value = value_lookup(key)
+        return value if value is not None else match.group(0)
+
+    return _PLACEHOLDER_RE.sub(_replacement, text)
+
+
+def format_instructions(text: str) -> str:
+    """Render the instruction template applying environment-driven substitutions."""
+
+    lookup = _placeholder_resolver()
+    # ``lookup.get`` already returns ``None`` for missing keys, preserving the token.
+    return _replace_placeholders(text, lookup.get)
 
 
 def _candidate_paths() -> tuple[Path, ...]:
@@ -38,12 +68,12 @@ def load_instructions() -> str:
                 content = path.read_text(encoding="utf-8").strip()
                 if content:
                     LOGGER.info("Using instructions from '%s'", path)
-                    return content
+                    return format_instructions(content)
         except OSError as exc:  # pragma: no cover - filesystem issues
             LOGGER.warning("Failed to read instructions from '%s': %s", path, exc)
 
     LOGGER.info("Using built-in instructions text")
-    return _DEFAULT_TEXT
+    return format_instructions(_DEFAULT_TEXT)
 
 
-__all__ = ["load_instructions"]
+__all__ = ["format_instructions", "load_instructions"]

--- a/app/server.py
+++ b/app/server.py
@@ -8,7 +8,9 @@ from .instructions import load_instructions
 from .patches import (
     ensure_sse_post_alias_patch,
     ensure_streamable_http_accept_patch,
+    ensure_streamable_http_instructions_patch,
     ensure_streamable_http_server_patch,
+    set_streamable_http_instructions,
 )
 from .tools import register_all
 
@@ -61,8 +63,12 @@ def create_app(
 ) -> FastMCP:
     """Create and configure the FastMCP application."""
 
+    instructions = load_instructions()
+    set_streamable_http_instructions(instructions)
+
     ensure_streamable_http_accept_patch()
     ensure_streamable_http_server_patch()
+    ensure_streamable_http_instructions_patch()
     ensure_sse_post_alias_patch()
 
     normalized_base_path = _normalize_mount_path(base_path)
@@ -75,8 +81,6 @@ def create_app(
         normalized_base_path,
         default_segment="mcp",
     )
-
-    instructions = load_instructions()
 
     app = FastMCP(
         name="mcp-grafana",

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -19,7 +19,7 @@ def clear_cache():
 def test_load_instructions_defaults_to_builtin(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MCP_INSTRUCTIONS_PATH", raising=False)
     value = load_instructions()
-    assert "Grafana" in value
+    assert "General Guidance" in value
 
 
 def test_load_instructions_uses_env_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -29,3 +29,18 @@ def test_load_instructions_uses_env_file(tmp_path: Path, monkeypatch: pytest.Mon
 
     value = load_instructions()
     assert value == "Custom instructions"
+
+
+def test_load_instructions_applies_placeholders(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    content = "UID={{DASH_UID}} FOLDER={{FOLDER_UID}} KEEP={{UNKNOWN}}"
+    custom = tmp_path / "prompt.md"
+    custom.write_text(content, encoding="utf-8")
+
+    monkeypatch.setenv("MCP_INSTRUCTIONS_PATH", str(custom))
+    monkeypatch.setenv("DASH_UID", "dash-123")
+    monkeypatch.setenv("FOLDER_UID", "folder-xyz")
+
+    value = load_instructions()
+    assert "dash-123" in value
+    assert "folder-xyz" in value
+    assert "{{UNKNOWN}}" in value

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -140,3 +140,29 @@ def test_ensure_sse_post_alias_patch_skips_when_fastmcp_missing(monkeypatch: pyt
 def test_ensure_sse_post_alias_patch_idempotent_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(patches, "_PATCH_SSE_ALIAS_APPLIED", True)
 
+    patches.ensure_sse_post_alias_patch()
+
+    assert patches._PATCH_SSE_ALIAS_APPLIED is True
+
+
+def test_set_streamable_http_instructions_assigns_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyTransport:
+        pass
+
+    monkeypatch.setattr(patches, "StreamableHTTPServerTransport", DummyTransport)
+    patches.set_streamable_http_instructions("  example ")
+
+    assert getattr(DummyTransport, "_fastmcp_preprompt_text") == "example"
+    assert patches._STREAMABLE_HTTP_INSTRUCTIONS == "example"
+
+
+def test_ensure_streamable_http_instructions_patch_noop_without_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyTransport:
+        pass
+
+    monkeypatch.setattr(patches, "StreamableHTTPServerTransport", DummyTransport)
+    monkeypatch.setattr(patches, "_PATCH_STREAMABLE_INSTRUCTIONS_APPLIED", False)
+
+    patches.ensure_streamable_http_instructions_patch()
+
+    assert patches._PATCH_STREAMABLE_INSTRUCTIONS_APPLIED is False


### PR DESCRIPTION
## Summary
- add environment-driven templating to instruction loading so prompts can embed deployment identifiers
- patch the streamable HTTP transport to emit session.update events with the configured preprompt and honour optional header overrides
- wire the new behaviour into server startup and extend the test suite to cover formatting and patch fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d37f165b30832eba41ea873915352f