### PR TITLE
Filter MCP tools based on Grafana capabilities

### DIFF
--- a/app/tools/__init__.py
+++ b/app/tools/__init__.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+from typing import Callable
+
 from mcp.server.fastmcp import FastMCP
 
+from ..config import grafana_config_from_env
 from . import (
     admin,
     alerting,
@@ -19,23 +23,84 @@ from . import (
     search,
     sift,
 )
+from .availability import GrafanaCapabilities, detect_capabilities
 
 __all__ = ["register_all"]
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_capabilities() -> GrafanaCapabilities:
+    config = grafana_config_from_env()
+    return detect_capabilities(config)
 
 
 def register_all(app: FastMCP) -> None:
     """Register all tool groups with the provided FastMCP application."""
 
-    admin.register(app)
-    datasources.register(app)
-    dashboard.register(app)
-    alerting.register(app)
-    asserts.register(app)
-    incident.register(app)
-    loki.register(app)
-    navigation.register(app)
-    oncall.register(app)
-    prometheus.register(app)
-    pyroscope.register(app)
-    search.register(app)
-    sift.register(app)
+    capabilities = _resolve_capabilities()
+
+    def _register(
+        name: str,
+        register_func: Callable[[FastMCP], None],
+        *,
+        supported: bool = True,
+        reason: str | None = None,
+    ) -> None:
+        if supported:
+            register_func(app)
+            return
+        message = reason or "required Grafana capability is not available"
+        LOGGER.info("Skipping registration of %s tools: %s", name, message)
+
+    _register("admin", admin.register)
+    _register("datasources", datasources.register)
+    _register("dashboard", dashboard.register)
+    _register("alerting", alerting.register)
+
+    has_irm_plugin = capabilities.has_plugin("grafana-irm-app")
+
+    _register(
+        "asserts",
+        asserts.register,
+        supported=capabilities.has_plugin("grafana-asserts-app"),
+        reason="requires the Grafana Asserts plugin (grafana-asserts-app)",
+    )
+    _register(
+        "incident",
+        incident.register,
+        supported=has_irm_plugin,
+        reason="requires the Grafana Incident plugin (grafana-irm-app)",
+    )
+    _register(
+        "loki",
+        loki.register,
+        supported=capabilities.has_datasource_type("loki"),
+        reason="requires a Grafana Loki datasource",
+    )
+    _register("navigation", navigation.register)
+    _register(
+        "oncall",
+        oncall.register,
+        supported=has_irm_plugin,
+        reason="requires the Grafana OnCall plugin (grafana-irm-app)",
+    )
+    _register(
+        "prometheus",
+        prometheus.register,
+        supported=capabilities.has_datasource_type("prometheus"),
+        reason="requires a Grafana Prometheus datasource",
+    )
+    _register(
+        "pyroscope",
+        pyroscope.register,
+        supported=capabilities.has_datasource_type("pyroscope"),
+        reason="requires a Grafana Pyroscope datasource",
+    )
+    _register("search", search.register)
+    _register(
+        "sift",
+        sift.register,
+        supported=capabilities.has_plugin("grafana-ml-app"),
+        reason="requires the Grafana Machine Learning plugin (grafana-ml-app)",
+    )

--- a/app/tools/availability.py
+++ b/app/tools/availability.py
@@ -1,0 +1,166 @@
+"""Utilities for detecting Grafana capabilities used during tool registration."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, FrozenSet, Iterable, Set
+
+from ..config import GrafanaConfig
+from ..grafana_client import GrafanaAPIError, GrafanaClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _normalize_items(values: Iterable[Any]) -> FrozenSet[str]:
+    normalized: Set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            value = str(value or "")
+        cleaned = value.strip().lower()
+        if cleaned:
+            normalized.add(cleaned)
+    return frozenset(normalized)
+
+
+@dataclass(frozen=True)
+class GrafanaCapabilities:
+    """Represents the Grafana features available to the MCP server."""
+
+    datasource_types: FrozenSet[str] = field(default_factory=frozenset)
+    plugin_ids: FrozenSet[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass hook
+        object.__setattr__(self, "datasource_types", _normalize_items(self.datasource_types))
+        object.__setattr__(self, "plugin_ids", _normalize_items(self.plugin_ids))
+
+    def has_datasource_type(self, expected: str) -> bool:
+        if not expected:
+            return False
+        normalized = expected.strip().lower()
+        return any(normalized in ds_type for ds_type in self.datasource_types)
+
+    def has_plugin(self, plugin_id: str) -> bool:
+        if not plugin_id:
+            return False
+        normalized = plugin_id.strip().lower()
+        return normalized in self.plugin_ids
+
+
+async def _fetch_datasource_types(client: GrafanaClient) -> Set[str]:
+    try:
+        payload = await client.get_json("/datasources")
+    except GrafanaAPIError as exc:  # pragma: no cover - defensive
+        LOGGER.info(
+            "Grafana datasources endpoint returned %s; assuming no datasource-based tools", exc.status_code
+        )
+        return set()
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.warning("Failed to list Grafana datasources", exc_info=True)
+        return set()
+
+    items: Iterable[Any]
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict):
+        candidate = payload.get("datasources") or payload.get("items")
+        if isinstance(candidate, list):
+            items = candidate
+        else:
+            LOGGER.debug("Unexpected datasources payload format: %r", payload)
+            return set()
+    else:
+        LOGGER.debug("Ignoring datasources payload of type %s", type(payload).__name__)
+        return set()
+
+    types: Set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        type_value = item.get("type")
+        if isinstance(type_value, str):
+            cleaned = type_value.strip().lower()
+            if cleaned:
+                types.add(cleaned)
+    return types
+
+
+async def _fetch_plugin_ids(client: GrafanaClient) -> Set[str]:
+    try:
+        payload = await client.get_json("/plugins")
+    except GrafanaAPIError as exc:  # pragma: no cover - defensive
+        LOGGER.info(
+            "Grafana plugins endpoint returned %s; plugin-dependent tools will be disabled", exc.status_code
+        )
+        return set()
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.warning("Failed to list Grafana plugins", exc_info=True)
+        return set()
+
+    items: Iterable[Any]
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict):
+        candidate = payload.get("items") or payload.get("plugins")
+        if isinstance(candidate, list):
+            items = candidate
+        else:
+            LOGGER.debug("Unexpected plugins payload format: %r", payload)
+            return set()
+    else:
+        LOGGER.debug("Ignoring plugins payload of type %s", type(payload).__name__)
+        return set()
+
+    plugin_ids: Set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        plugin_id = item.get("id")
+        if isinstance(plugin_id, str):
+            cleaned = plugin_id.strip().lower()
+            if cleaned:
+                plugin_ids.add(cleaned)
+    return plugin_ids
+
+
+async def _collect_capabilities(config: GrafanaConfig) -> GrafanaCapabilities:
+    client = GrafanaClient(config)
+    datasource_types, plugin_ids = await asyncio.gather(
+        _fetch_datasource_types(client),
+        _fetch_plugin_ids(client),
+    )
+    LOGGER.debug(
+        "Detected Grafana capabilities",
+        extra={
+            "datasource_types": sorted(datasource_types),
+            "plugin_ids": sorted(plugin_ids),
+        },
+    )
+    return GrafanaCapabilities(datasource_types=frozenset(datasource_types), plugin_ids=frozenset(plugin_ids))
+
+
+def detect_capabilities(config: GrafanaConfig) -> GrafanaCapabilities:
+    """Synchronously detect Grafana capabilities for tool registration."""
+
+    try:
+        return asyncio.run(_collect_capabilities(config))
+    except RuntimeError as exc:
+        message = str(exc)
+        if "asyncio.run" not in message:
+            LOGGER.warning("Capability detection failed", exc_info=True)
+            return GrafanaCapabilities()
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(_collect_capabilities(config))
+        except Exception:  # pragma: no cover - defensive
+            LOGGER.warning("Capability detection failed inside fallback loop", exc_info=True)
+            return GrafanaCapabilities()
+        finally:
+            loop.close()
+    except Exception:  # pragma: no cover - defensive
+        LOGGER.warning("Capability detection failed", exc_info=True)
+        return GrafanaCapabilities()
+
+
+__all__ = ["GrafanaCapabilities", "detect_capabilities"]

--- a/tests/test_tool_availability.py
+++ b/tests/test_tool_availability.py
@@ -1,0 +1,70 @@
+"""Tests for Grafana capability detection used during tool registration."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from app.config import GrafanaConfig
+from app.tools import availability
+
+
+class DummyGrafanaClient:
+    def __init__(self, config: GrafanaConfig) -> None:
+        self.config = config
+        self.calls: list[str] = []
+
+    async def get_json(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        self.calls.append(path)
+        if path == "/datasources":
+            return [
+                {"type": "loki"},
+                {"type": "Prometheus"},
+                {"type": None},
+                {"missing": True},
+            ]
+        if path == "/plugins":
+            return [
+                {"id": "grafana-ml-app"},
+                {"id": "Grafana-IRM-App"},
+                {"id": None},
+            ]
+        raise AssertionError(f"Unexpected path requested: {path}")
+
+
+def test_detect_capabilities_normalizes_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(availability, "GrafanaClient", DummyGrafanaClient)
+
+    config = GrafanaConfig(url="https://grafana.example.com")
+    capabilities = availability.detect_capabilities(config)
+
+    assert capabilities.has_datasource_type("LOKI")
+    assert capabilities.has_datasource_type("prometheus")
+    assert not capabilities.has_datasource_type("pyroscope")
+
+    assert capabilities.has_plugin("grafana-ml-app")
+    assert capabilities.has_plugin("grafana-irm-app")
+    assert not capabilities.has_plugin("grafana-asserts-app")
+
+
+def test_detect_capabilities_handles_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def fake_collect(config: GrafanaConfig) -> availability.GrafanaCapabilities:
+        calls.append("collect")
+        return availability.GrafanaCapabilities()
+
+    monkeypatch.setattr(availability, "_collect_capabilities", fake_collect)
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        capabilities = availability.detect_capabilities(GrafanaConfig())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+    assert isinstance(capabilities, availability.GrafanaCapabilities)
+    assert calls == ["collect"]

--- a/tests/test_tools_registration.py
+++ b/tests/test_tools_registration.py
@@ -1,0 +1,55 @@
+"""Integration-style tests for conditional tool registration."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import app.tools as tools
+from app.tools import register_all
+from app.tools.availability import GrafanaCapabilities
+from mcp.server.fastmcp import FastMCP
+
+
+def _capabilities_with(*, datasource_types: set[str], plugin_ids: set[str]) -> GrafanaCapabilities:
+    return GrafanaCapabilities(
+        datasource_types=frozenset(datasource_types),
+        plugin_ids=frozenset(plugin_ids),
+    )
+
+
+def _tool_names(app: FastMCP) -> set[str]:
+    registered = asyncio.run(app.list_tools())
+    return {tool.name for tool in registered}
+
+
+def test_register_all_skips_loki_without_datasource(monkeypatch: pytest.MonkeyPatch) -> None:
+    capabilities = _capabilities_with(
+        datasource_types={"prometheus", "pyroscope"},
+        plugin_ids={"grafana-irm-app", "grafana-asserts-app", "grafana-ml-app"},
+    )
+    monkeypatch.setattr(tools, "_resolve_capabilities", lambda: capabilities)
+
+    app = FastMCP()
+    register_all(app)
+    names = _tool_names(app)
+
+    assert "query_loki_logs" not in names
+    assert "search" in names
+
+
+def test_register_all_skips_oncall_without_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
+    capabilities = _capabilities_with(
+        datasource_types={"loki", "prometheus", "pyroscope"},
+        plugin_ids={"grafana-ml-app"},
+    )
+    monkeypatch.setattr(tools, "_resolve_capabilities", lambda: capabilities)
+
+    app = FastMCP()
+    register_all(app)
+    names = _tool_names(app)
+
+    assert "list_oncall_schedules" not in names
+    assert "create_incident" not in names
+    assert "search" in names

--- a/tests/test_tools_search.py
+++ b/tests/test_tools_search.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import pytest
 
+import app.tools as tools
 from app.tools import register_all
+from app.tools.availability import GrafanaCapabilities
 from app.tools.search import (
     _fetch_dashboard,
     _fetch_resource,
@@ -13,6 +15,15 @@ from app.tools.search import (
     _resolve_dashboard_lookup,
 )
 from mcp.server.fastmcp import FastMCP
+
+
+@pytest.fixture(autouse=True)
+def _allow_all_capabilities(monkeypatch: pytest.MonkeyPatch) -> None:
+    capabilities = GrafanaCapabilities(
+        datasource_types=frozenset({"loki", "prometheus", "pyroscope"}),
+        plugin_ids=frozenset({"grafana-irm-app", "grafana-asserts-app", "grafana-ml-app"}),
+    )
+    monkeypatch.setattr(tools, "_resolve_capabilities", lambda: capabilities)
 
 
 def test_search_tool_is_registered() -> None:


### PR DESCRIPTION
## Summary
- add a Grafana capability detector that queries available datasource types and plugins
- register MCP tool groups only when the required Grafana capabilities are present
- cover the capability detection and conditional registration logic with new tests and update existing search tool tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d42a4a8754832e95c40f099c230fc3