### PR TITLE
Ensure tool parameters include object schema

### DIFF
--- a/mcp/server/fastmcp.py
+++ b/mcp/server/fastmcp.py
@@ -27,6 +27,7 @@ class ToolDefinition:
     title: str
     description: str
     inputSchema: Dict[str, Any]
+    parameters: Dict[str, Any]
     function: Callable[..., Awaitable[Any]]
     signature: inspect.Signature = field(repr=False)
 
@@ -140,6 +141,7 @@ class FastMCP:
                 title=title,
                 description=description,
                 inputSchema=schema,
+                parameters=schema,
                 function=func,
                 signature=inspect.signature(func),
             )
@@ -336,6 +338,7 @@ class _STDIOHandler:
                 "title": tool.title,
                 "description": tool.description,
                 "inputSchema": tool.inputSchema,
+                "parameters": tool.parameters,
             }
             annotations = {}
             if tool.title:

--- a/tests/test_fastmcp_stdio.py
+++ b/tests/test_fastmcp_stdio.py
@@ -57,6 +57,30 @@ def test_stdio_list_tools_returns_registered_tool() -> None:
     assert len(tools) == 1
     assert tools[0]["name"] == "echo"
     assert tools[0]["inputSchema"]["type"] == "object"
+    assert tools[0]["parameters"]["type"] == "object"
+    assert tools[0]["parameters"] == tools[0]["inputSchema"]
+
+
+def test_stdio_list_tools_includes_empty_parameters_for_no_argument_tool() -> None:
+    app = FastMCP(name="mcp-grafana", instructions=None)
+
+    @app.tool(name="noop", title="Noop", description="No arguments")
+    async def noop() -> Dict[str, str]:
+        return {"result": "ok"}
+
+    handler = _STDIOHandler(app)
+    _initialize(handler)
+
+    response = handler._handle_request({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/list",
+        "params": {},
+    })
+
+    tool = response["result"]["tools"][0]
+    assert tool["parameters"]["type"] == "object"
+    assert tool["parameters"].get("properties") == {}
 
 
 def test_stdio_call_tool_invokes_async_function() -> None:


### PR DESCRIPTION
## Summary
- expose tool parameter schemas alongside the existing input schema metadata
- ensure tools without arguments still return an object schema with empty properties and cover via tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4312f8284832ebf0ba1128de4a42c