### PR TITLE
Fix FastMCP array schema items

### DIFF
--- a/tests/test_tools_search.py
+++ b/tests/test_tools_search.py
@@ -87,6 +87,22 @@ def test_fetch_schema_exposes_string_identifiers() -> None:
     assert id_schema.get("type") == "string"
 
 
+def test_fetch_schema_defines_array_items_for_ids() -> None:
+    app = FastMCP()
+    register_all(app)
+
+    tools = asyncio.run(app.list_tools())
+    tool = next((tool for tool in tools if tool.name == "fetch"), None)
+    assert tool is not None
+
+    schema = tool.inputSchema
+    ids_schema = schema.get("properties", {}).get("ids")
+    assert ids_schema is not None, schema
+    assert ids_schema.get("type") == "array"
+    assert "items" in ids_schema
+    assert isinstance(ids_schema["items"], dict)
+
+
 def test_parse_dashboard_url_handles_relative_and_absolute_paths() -> None:
     uid, numeric = _parse_dashboard_url("/d/abc123/example")
     assert uid == "abc123"


### PR DESCRIPTION
## Summary
- ensure FastMCP array annotations now emit JSON schema `items` metadata for both runtime and string annotations
- support sequences and unions when inferring array item schemas
- add a regression test confirming the fetch tool exposes an array schema with `items`

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d46b1bddf0832e977cbba4d9cc06ec