### PR TITLE
Suporte a publicação no PyPI, execução com UVX e GH Workflow p/ auto-publish no PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build -s -w -o dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 Todas as mudanças notáveis deste projeto são registradas neste arquivo. Este formato segue as recomendações do "Keep a Changelog" e o projeto adota versionamento semântico (semver).
+## [v1.2.1] - 2025-10-19
+### 🚀 Adicionado
+- Suporte a publicação no PyPI usando `uv build` e `uv publish --token {PYPI_API_TOKEN}`
+- Execução com env dinâmico usando `uvx grafana-fastmcp`, diretamente do PyPI
+- Pequenos ajustes no .toml para suporte ao endpoint de execução app:__main__:main
+- GitHUB Action workflow para publicação automatica no PyPI à partir de PR
 
 ## [v1.2.0] – 2025-10-18
 ### 🚀 Adicionado
@@ -23,6 +29,7 @@ Todas as mudanças notáveis deste projeto são registradas neste arquivo. Este 
 - Workflow PR reduzido para executar testes somente em Python 3.13 por padrão (rápido feedback para reviewers).
 - Pipeline principal (`.github/workflows/python-package.yml`) restrito para rodar em push para `main` usando Python 3.13.
 - Job condicional `build-artifacts` (PR) que constrói wheel e binário com PyInstaller quando o rótulo `build-artifacts` é aplicado.
+ - Adicionado workflow de publicação no PyPI acionado por tag `v*.*.*` (sdist + wheel). A CLI publicada expõe o comando `grafana-fastmcp` para uso com `uvx`.
 
 ### 📚 Documentação
 - `README.md` atualizado com instruções para `uv`, badges reais do repositório, explicação sobre o rótulo `build-artifacts` e nota sobre baseline Python 3.13+.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ uv sync --dev --all-extras
 uv run -m app --address localhost:8000 --log-level INFO --transport stdio
 ```
 
+Também é possível executar via PyPI usando uvx (após a publicação):
+```bash
+uvx grafana-fastmcp --address localhost:8000 --log-level INFO --transport stdio
+```
+
 4. Comandos comuns:
 ```bash
 # Testes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "grafana-fastmcp"
-version = "1.2.0"
+version = "1.2.1"
 description = "Python Grafana FastMCP server/CLI with SSE, Streamable HTTP and STDIO transports"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -35,7 +35,7 @@ sse = [
 ]
 
 [project.scripts]
-grafana-mcp = "app.main:main"
+grafana-fastmcp = "app.main:main"
 
 [project.urls]
 Homepage = "https://github.com/sandersouza/grafanaFastMCP"


### PR DESCRIPTION
## [v1.2.1] - 2025-10-19
### 🚀 Adicionado
- Suporte a publicação no PyPI usando `uv build` e `uv publish --token {PYPI_API_TOKEN}`
- Execução com env dinâmico usando `uvx grafana-fastmcp`, diretamente do PyPI
- Pequenos ajustes no .toml para suporte ao endpoint de execução app:__main__:main
- GitHUB Action workflow para publicação automatica no PyPI à partir de PR

Close #22
build-artifacts